### PR TITLE
Artifact feed Uri support for legacy VSTS domains

### DIFF
--- a/buildtask/index.ts
+++ b/buildtask/index.ts
@@ -56,6 +56,8 @@ async function run() {
         if (useArtifacts) {
             var artifactsUri = collectionUri + "_packaging/" + artifactsFeeds + "/nuget/v3/index.json";
             artifactsUri = artifactsUri.replace("dev.azure.com", "pkgs.dev.azure.com");
+            // Add support for legacy Uri
+            artifactsUri = artifactsUri.replace("visualstudio.com", "pkgs.visualstudio.com");
             arg.push("--azure-artifacts-uri", artifactsUri);
         }
 


### PR DESCRIPTION
Devops supports both new and legacy Uri's : 
https://{org}.visualstudio.com vs dev.azure.com/{org}

For those that haven't enabled the new Uri, pipelines will set SYSTEM_COLLECTIONURI to {org.visualstudio.com}, thus the injection of  "pkgs." doesn't occur resulting in an invalid Uri.

https://{org}.visualstudio.com/_packaging/{guid}/nuget/v3/index.json
vs
https://{org}.pkgs.visualstudio.com/_packaging/{guid}/nuget/v3/index.json